### PR TITLE
Fix attempt to remove unexistent files

### DIFF
--- a/src/Downloader/TranslationDownloader.php
+++ b/src/Downloader/TranslationDownloader.php
@@ -138,30 +138,23 @@ class TranslationDownloader
         return true;
     }
 
-    public function remove(TranslatablePackage $transPackage, array $allowedLanguages)
+    public function remove(TranslatablePackage $transPackage)
     {
         $directory = $transPackage->languageDirectory();
-        $translations = $transPackage->translations($allowedLanguages);
+        $basePath = rtrim($directory, '/').'/'.$transPackage->projectName();
 
-        foreach ($translations as $translation) {
-            $language = $translation['language'];
-            $files = [
-                $directory.$transPackage->projectName().'-'.$language.'.mo',
-                $directory.$transPackage->projectName().'-'.$language.'.po',
-            ];
-            foreach ($files as $file) {
-                try {
-                    $this->filesystem->unlink($file);
-                    $this->io->write(
-                        sprintf(
-                            "    - <info>[OK]</info> %s: deleted %s translation file.",
-                            $transPackage->projectName(),
-                            basename($file)
-                        )
-                    );
-                } catch (\Throwable $exception) {
-                    $this->io->error($exception->getMessage());
-                }
+        foreach (glob("{$basePath}-*.{po,mo}", GLOB_BRACE) as $file) {
+            try {
+                $this->filesystem->unlink($file);
+                $this->io->write(
+                    sprintf(
+                        "    - <info>[OK]</info> %s: deleted %s translation file.",
+                        $transPackage->projectName(),
+                        basename($file)
+                    )
+                );
+            } catch (\Throwable $exception) {
+                $this->io->error($exception->getMessage());
             }
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -168,15 +168,11 @@ final class Plugin implements
      */
     public function onPackageUninstall(PackageEvent $event)
     {
-        /** @var PackageInterface|TranslatablePackage $transPackage */
+        /** @var PackageInterface|TranslatablePackage|null $transPackage */
         $transPackage = $this->translatablePackageFactory->createFromOperation($event->getOperation());
-
-        if ($transPackage === null) {
-            return;
+        if ($transPackage) {
+            $this->translationDownloader->remove($transPackage);
         }
-
-        $allowedLanguages = $this->pluginConfig->allowedLanguages();
-        $this->translationDownloader->remove($transPackage, $allowedLanguages);
     }
 
     /**


### PR DESCRIPTION
When a Composer package is unistalled, `wp-translation-downloader` tries to remove the existent translations for it.

The way that is done currently, is to loop the translation files that are _expected_ to be there and call `Filesystem::unlink()` for each of them.

The problem is that  translation files that are _expected_ to be there, often are not there.

For example, some tranlations could have been not available when `wp-translation-downloader` was executed so files were not downloaded, or in the case a package is removed before any translation was downloaded at all.

Because `Filesystem::unlink()` does not check if a file exists before attempting the removal, right now `wp-translation-downloader` triggers a lot of errors due to attempts of removing files that do no exist.

Checking for `file_exists` could be an option, but that would eman to call `file_exists`  _n_ times, one per each language.

This PR instead uses `glob` to only get existing translation files for the package that has been removed, and then call `Filesystem::unlink()` for each of them.

In this case if `Filesystem::unlink()` fails it really for an error that is worth showing.