### PR TITLE
Feature virtual packages

### DIFF
--- a/docs/Configuraton.md
+++ b/docs/Configuraton.md
@@ -275,4 +275,4 @@ We allow to lock a version optionally, since WordPress.org Translation API resol
 | `"5.9"`        | https://api.wordpress.org/translations/core/1.0/?version=5.9   |
 | `"5.9.3"`      | https://api.wordpress.org/translations/core/1.0/?version=5.9.3 |
 | `""`           | https://api.wordpress.org/translations/core/1.0/               |
-| _none set      | https://api.wordpress.org/translations/core/1.0/               |
+| _none set_     | https://api.wordpress.org/translations/core/1.0/               |

--- a/docs/Configuraton.md
+++ b/docs/Configuraton.md
@@ -244,7 +244,7 @@ into `/{root path}/public/languages/some-folder/`.
 ## Virtual Packages
 Sometimes it is required to not define a dependency in `composer.json` via `require` or `require-dev` but still need the translations to be installed. That can be the case in the WordPress-world for hosting solutions or dockerized enviornments like https://hub.docker.com/_/wordpress which already shipping WordPress pre-installed.
 
-To install translations for "pre-installed platform" dependencies we introduced `virtual-packages` as part of the `wp-translation-downloader`-configuration. The following example will download additionally to all `require`-dependencies of `composer.json` the WordPress core translations:
+To install translations for "pre-installed platform dependencies", we introduced `virtual-packages` as part of the `wp-translation-downloader`-configuration. The following example will download additionally to all `require`-dependencies of `composer.json` the WordPress core translations:
 
 ```json
 {
@@ -262,13 +262,13 @@ To install translations for "pre-installed platform" dependencies we introduced 
 
 The configuration fields are following:
 
-| field     | required | type     | description                                                                          |
-|-----------|----------|----------|--------------------------------------------------------------------------------------|
-| `name`    | x        | `string` | The packageName of your pre-installed dependency.                                    |
-| `type`    | x        | `string` | The type which is usally defined in `composer.json` to resolve the correct endpoint. |
-| `version` |          | `string` | The string in which version you want to install the translations.                    |
+| field     | required | type     | description                                                                           |
+|-----------|----------|----------|---------------------------------------------------------------------------------------|
+| `name`    | x        | `string` | The packageName of your pre-installed dependency.                                     |
+| `type`    | x        | `string` | The type which is usually defined in `composer.json` to resolve the correct endpoint. |
+| `version` |          | `string` | The string in which version you want to install the translations.                     |
 
-We allow to lock a version optionally, since WordPress.org Translation API resolves translations dynamically via `?version=`. When the field is being empty the latest translations will be downloaded.
+We allow to lock a version optionally, since WordPress.org Translation API resolves translations dynamically via `?version={version}`. When the field is being empty the latest translations will be downloaded.
 
 | version string | endpoint                                                       |
 |----------------|----------------------------------------------------------------|

--- a/docs/Configuraton.md
+++ b/docs/Configuraton.md
@@ -13,6 +13,7 @@ The following configuration properties are available:
 | `languageRootDir`   | `string`   | x        | The relative path to the `languages` directory - replaces `directory`-key.       |
 | `directories.names` | `array`    | x        | Array of package names mapped to `language`sub-folders.                          |
 | `directories.types` | `array`    | x        | Array of package types mapped to `language` sub-folder.                          |
+| `virtual-packages`  | `array`    |          | An array of objects with `name`, `type` and optionally `version`.                |
 
 > **[!] Note:** You can use `*` as wildcard in the `exclude`, `api.names`, `api.types`, `directories.names`
 > and `directories.types` properties.
@@ -238,3 +239,40 @@ To change the directory for a specific package by name you can do following:
 
 This will place the package with `"name": "my/package-name"` in composer.json
 into `/{root path}/public/languages/some-folder/`.
+
+
+## Virtual Packages
+Sometimes it is required to not define a dependency in `composer.json` via `require` or `require-dev` but still need the translations to be installed. That can be the case in the WordPress-world for hosting solutions or dockerized enviornments like https://hub.docker.com/_/wordpress which already shipping WordPress pre-installed.
+
+To install translations for "pre-installed platform" dependencies we introduced `virtual-packages` as part of the `wp-translation-downloader`-configuration. The following example will download additionally to all `require`-dependencies of `composer.json` the WordPress core translations:
+
+```json
+{
+    "languageRootDir": "public/languages/",
+    "languages": ["de_DE"],
+    "virtual-packages": [
+        {
+            "name": "johnpbloch/wordpress",
+            "type": "wordpress-core",
+            "version": "5.8"
+        }
+    ]
+}
+```
+
+The configuration fields are following:
+
+| field     | required | type     | description                                                                          |
+|-----------|----------|----------|--------------------------------------------------------------------------------------|
+| `name`    | x        | `string` | The packageName of your pre-installed dependency.                                    |
+| `type`    | x        | `string` | The type which is usally defined in `composer.json` to resolve the correct endpoint. |
+| `version` |          | `string` | The string in which version you want to install the translations.                    |
+
+We allow to lock a version optionally, since WordPress.org Translation API resolves translations dynamically via `?version=`. When the field is being empty the latest translations will be downloaded.
+
+| version string | endpoint                                                       |
+|----------------|----------------------------------------------------------------|
+| `"5.9"`        | https://api.wordpress.org/translations/core/1.0/?version=5.9   |
+| `"5.9.3"`      | https://api.wordpress.org/translations/core/1.0/?version=5.9.3 |
+| `""`           | https://api.wordpress.org/translations/core/1.0/               |
+| _none set      | https://api.wordpress.org/translations/core/1.0/               |

--- a/resources/wp-translation-downloader-schema.json
+++ b/resources/wp-translation-downloader-schema.json
@@ -84,6 +84,31 @@
                     }
                 }
             }
+        },
+        "virtual-packages": {
+            "title": "Allows to define already installed dependencies without going through require/require-dev.",
+            "type": "array",
+            "items": [
+                {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "type"
+                    ]
+                }
+            ]
         }
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,6 +18,7 @@ use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
+use Composer\Package\Package;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\Capability\CommandProvider;
 use Composer\Plugin\Capable;
@@ -239,6 +240,10 @@ final class Plugin implements
 
         // Add root package as well to be processed.
         $packages[] = $event->getComposer()->getPackage();
+
+        foreach ($this->pluginConfig->virtualPackages() as $package) {
+            $packages[] = $package;
+        }
 
         $this->doUpdatePackages($packages);
     }

--- a/src/Util/Remover.php
+++ b/src/Util/Remover.php
@@ -47,6 +47,7 @@ class Remover
         Filesystem $filesystem,
         Locker $locker
     ) {
+
         $this->io = $io;
         $this->filesystem = $filesystem;
         $this->locker = $locker;

--- a/tests/Behat/features/virtual-packages.feature
+++ b/tests/Behat/features/virtual-packages.feature
@@ -1,0 +1,10 @@
+Feature: Testing if virtual packages translations are downloaded as well.
+  See: ./tests/fixtures/virtual-packages/composer.json
+
+  Scenario: Installing with virtual packages
+    Given I am using the fixtures "virtual-packages"
+    When I run composer install
+    Then I should see the folder "languages" exists
+	Then I should see in console "backwpup: found 1 translations"
+	And I should see in console "wordpress: found 1 translations"
+	And I should see the file "languages/de_DE.mo" exists

--- a/tests/Unit/Config/PluginConfigurationBuilderTest.php
+++ b/tests/Unit/Config/PluginConfigurationBuilderTest.php
@@ -122,6 +122,11 @@ class PluginConfigurationBuilderTest extends TestCase
             ['languages' => ['de_DE'], 'excludes' => ['inpsyde/google-tag-manager']],
             true,
         ];
+
+        yield 'virtual-packages' => [
+            ['languages' => ['de_DE'], 'virtual-packages' => [['name' => 'wordpress/core', 'type' => 'wordpress-core']]],
+            true
+        ];
     }
 
     /**
@@ -144,6 +149,16 @@ class PluginConfigurationBuilderTest extends TestCase
         yield 'Incorrect languageRootDir' => [
             ['languages' => ['de_DE'], 'languageRootDir' => false],
             false,
+        ];
+
+        yield 'Incorrect virtual-packages - missing name' => [
+            ['languages' => ['de_DE'], 'virtual-packages' => [['type' => 'wordpress-core']]],
+            false
+        ];
+
+        yield 'Incorrect virtual-packages - missing type' => [
+            ['languages' => ['de_DE'], 'virtual-packages' => [['name' => 'wordpress/core']]],
+            false
         ];
     }
 }

--- a/tests/Unit/Config/PluginConfigurationTest.php
+++ b/tests/Unit/Config/PluginConfigurationTest.php
@@ -27,6 +27,7 @@ class PluginConfigurationTest extends TestCase
         $testee = new PluginConfiguration([]);
 
         static::assertEmpty($testee->allowedLanguages());
+        static::assertEmpty($testee->virtualPackages());
         static::assertTrue($testee->autorun());
 
         // Default API configuration
@@ -37,6 +38,47 @@ class PluginConfigurationTest extends TestCase
         static::assertNotEmpty($testee->languageRootDir());
         static::assertEmpty($testee->directoryBy(PluginConfiguration::BY_NAME));
         static::assertNotEmpty($testee->directoryBy(PluginConfiguration::BY_TYPE));
+    }
+
+    /**
+     * @test
+     */
+    public function testVirtualPackages(): void
+    {
+        $expectedName1 = 'name1';
+        $expectedType1 = 'type1';
+        $expectedVersion1 = '1.0';
+        $expectedName2 = 'name2';
+        $expectedType2 = 'type2';
+        $expectedName3 = 'name3';
+        $expectedType3 = 'type3';
+
+        $testee = new PluginConfiguration([
+            'virtual-packages' => [
+                ['name' => $expectedName1, 'type' => $expectedType1, 'version' => $expectedVersion1],
+                ['name' => $expectedName2, 'type' => $expectedType2, 'version' => ''],
+                ['name' => $expectedName3, 'type' => $expectedType3],
+            ],
+        ]);
+
+        $virtualPackages= $testee->virtualPackages();
+        static::assertCount(3, $virtualPackages);
+
+        $package1 = $virtualPackages[0];
+        static::assertSame($expectedName1, $package1->getName());
+        static::assertSame($expectedType1, $package1->getType());
+        static::assertSame($expectedVersion1, $package1->getVersion());
+
+        $package2 = $virtualPackages[1];
+        static::assertSame($expectedName2, $package2->getName());
+        static::assertSame($expectedType2, $package2->getType());
+        static::assertSame('', $package2->getVersion());
+
+
+        $package3 = $virtualPackages[2];
+        static::assertSame($expectedName3, $package3->getName());
+        static::assertSame($expectedType3, $package3->getType());
+        static::assertSame('', $package3->getVersion());
     }
 
     /**

--- a/tests/Unit/Package/TranslatablePackageFactoryTest.php
+++ b/tests/Unit/Package/TranslatablePackageFactoryTest.php
@@ -262,4 +262,51 @@ class TranslatablePackageFactoryTest extends TestCase
         ];
     }
 
+    /**
+     * @test
+     * @dataProvider provideRemoveEmptyQueryParams
+     */
+    public function testRemoveEmptyQueryParams(string $expected, string $input): void
+    {
+        $testee = new class extends TranslatablePackageFactory {
+            public function __construct()
+            {
+            }
+
+            public function removeEmptyQueryParams(string $url): string
+            {
+                return parent::removeEmptyQueryParams($url);
+            }
+        };
+
+        static::assertSame($expected, $testee->removeEmptyQueryParams($input));
+    }
+
+    public function provideRemoveEmptyQueryParams(): \Generator
+    {
+        yield 'no empty query param' => [
+            "https://api.wordpress.org/translations/core/1.0/",
+            "https://api.wordpress.org/translations/core/1.0/",
+        ];
+
+        yield 'empty query param' => [
+            "https://api.wordpress.org/translations/core/1.0/",
+            "https://api.wordpress.org/translations/core/1.0/?version=",
+        ];
+
+        yield 'multiple query params' => [
+            "https://api.wordpress.org/translations/core/1.0/?foo=bar",
+            "https://api.wordpress.org/translations/core/1.0/?foo=bar&version=",
+        ];
+
+        yield 'multiple query params 2' => [
+            "https://api.wordpress.org/translations/core/1.0/?foo=bar",
+            "https://api.wordpress.org/translations/core/1.0/?version=&foo=bar",
+        ];
+
+        yield 'multiple empty query params ' => [
+            "https://api.wordpress.org/translations/core/1.0/?baz=baz",
+            "https://api.wordpress.org/translations/core/1.0/?foo=&bar&baz=baz",
+        ];
+    }
 }

--- a/tests/fixtures/virtual-packages/composer.json
+++ b/tests/fixtures/virtual-packages/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "wp-translation-downloader/excludes",
+    "minimum-stability": "dev",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://wpackagist.org"
+        },
+        {
+            "type": "path",
+            "url": "../../../"
+        }
+    ],
+    "require": {
+        "inpsyde/wp-translation-downloader": "*",
+        "wpackagist-plugin/backwpup": "3.10.0"
+    },
+    "extra": {
+        "wp-translation-downloader": {
+            "languages": [
+                "de_DE"
+            ],
+            "languageRootDir": "languages/",
+            "virtual-packages": [
+                {
+                    "name": "johnpbloch/wordpress",
+                    "version": "5.9.3",
+                    "type": "wordpress-core"
+                }
+            ]
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "johnpbloch/wordpress-core-installer": true,
+            "inpsyde/wp-translation-downloader": true
+        }
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR solves the issue when a platform has already pre-installed dependencies which are not part of the `composer.json` `require` or `require-dev` part. This will allow to have for example "WordPress" defined as `virtual-dependency` and download translations without having it resolved via `composer.json` as dependency.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope. Just new feature.
