### PR TITLE
Make use of HttpDownloader and JsonFile for downloading the TranslatePackage translations.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -249,8 +249,6 @@ By using the above configuration, the package `my/package-name` will have transl
 The `directories` configuration, both by name and by type, supports 
 [dynamic resolving via placeholders](./Dynamic%20resolving%20api%20and%20directories.md).
 
-
-
 ## Virtual Packages
 
 It might be desirable to install translations for packages that are *not* required in Composer.
@@ -291,3 +289,11 @@ passed, assuming latest version, if none is passed.
 
 In any case, all three properties (if defined and not empty), will be used when building the
 API endpoint (no matter if default or customized by name/type).
+
+## Authentication for privately hosted translations
+
+Your private GlotPress system is probably secured with one or more authentication options. In order to allow your project to have access to these endpoints and translations file archives you will have to tell Composer how to authenticate with the server that hosts them.
+
+`inpsyde/wp-translation-downloader` makes use of the full Composer PHP API and therefor uses the `Composer\Util\HttpDownloader`. This implementation accesses internally the configured Composer defined credentials.
+
+Credentials can be stored on 4 different places; in an `auth.json` for the project, a global `auth.json`, in the `composer.json` itself or in the `COMPOSER_AUTH` environment variable. Read more about configuration of authentication in Composer here: https://getcomposer.org/doc/articles/authentication-for-private-packages.md

--- a/src/Package/TranslatablePackageFactory.php
+++ b/src/Package/TranslatablePackageFactory.php
@@ -98,17 +98,20 @@ class TranslatablePackageFactory
             [$endpoint, $endpointType] = $endpointData;
 
             $jsonFile = new JsonFile($endpoint, $this->downloader, $this->io);
+            /** @var array|null $translations */
             $translations = $jsonFile->read();
             if (! $translations) {
                 return null;
             }
+
+            $translations = (array) ($translations['translations'] ?? []);
 
             return new TranslatablePackage(
                 $package,
                 $directory,
                 $endpoint,
                 $endpointType,
-                (array) ($translations['translations'] ?? [])
+                $translations
             );
         } catch (\Throwable $exception) {
             $this->io->error($exception->getMessage());

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -31,7 +31,6 @@ use Inpsyde\WpTranslationDownloader\Command\CleanUpCommand;
 use Inpsyde\WpTranslationDownloader\Command\DownloadCommand;
 use Inpsyde\WpTranslationDownloader\Config\PluginConfiguration;
 use Inpsyde\WpTranslationDownloader\Config\PluginConfigurationBuilder;
-use Inpsyde\WpTranslationDownloader\Util\ArchiveDownloaderFactory;
 use Inpsyde\WpTranslationDownloader\Util\Downloader;
 use Inpsyde\WpTranslationDownloader\Package\TranslatablePackageFactory;
 use Inpsyde\WpTranslationDownloader\Util\Locker;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,6 +16,7 @@ namespace Inpsyde\WpTranslationDownloader;
 use Composer\Command\BaseCommand;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Factory;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
 use Composer\Package\CompletePackage;
@@ -147,7 +148,11 @@ final class Plugin implements
             return;
         }
 
-        $this->translatablePackageFactory = new TranslatablePackageFactory($this->pluginConfig);
+        $this->translatablePackageFactory = new TranslatablePackageFactory(
+            $this->pluginConfig,
+            Factory::createHttpDownloader($io, $composer->getConfig()),
+            $this->io
+        );
 
         $this->translationsDownloader = new TranslationPackageDownloader(
             $composer->getLoop(),

--- a/tests/Unit/Package/ProjectTranslationTest.php
+++ b/tests/Unit/Package/ProjectTranslationTest.php
@@ -6,7 +6,6 @@ namespace Inpsyde\WpTranslationDownloader\Tests\Unit\Package;
 
 use Composer\Package\CompletePackage;
 use Composer\Package\Package;
-use Inpsyde\WpTranslationDownloader\Package\ProjectTranslation;
 use Inpsyde\WpTranslationDownloader\Package\TranslatablePackage;
 use PHPUnit\Framework\TestCase;
 
@@ -30,15 +29,9 @@ class ProjectTranslationTest extends TestCase
                     new CompletePackage('test/test', '1.0.0.0', '1.0'),
                     __DIR__,
                     'https://example.com/test/test/translations',
-                    $endpointFileType
+                    $endpointFileType,
+                    [$this->data]
                 );
-            }
-
-            protected function loadTranslations(): bool
-            {
-                $this->translations = $this->parseTranslations([$this->data]);
-
-                return true;
             }
         };
 
@@ -215,6 +208,7 @@ class ProjectTranslationTest extends TestCase
 	]
 }
 JSON;
+
         $translatablePackage = new class ($json) extends TranslatablePackage
         {
             private $json;
@@ -224,15 +218,19 @@ JSON;
                 parent::__construct(
                     new Package('test/test', '2.0.5.0', '1.2.0.5'),
                     __DIR__,
-                    'https://example.com'
+                    'https://example.com',
+                    null,
+                    $this->readEndpointContent('')['translations'] ?? []
                 );
             }
 
-            protected function readEndpointContent(string $apiUrl): ?array
+            protected function readEndpointContent(string $apiUrl): array
             {
                 $result = json_decode($this->json, true);
 
-                return is_array($result) ? $result : null;
+                return is_array($result)
+                    ? $result
+                    : [];
             }
         };
 

--- a/tests/Unit/Package/TranslatablePackageTest.php
+++ b/tests/Unit/Package/TranslatablePackageTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Inpsyde\WpTranslationDownloader\Tests\Unit\Package;
 
 use Composer\Package\Package;
-use Composer\Package\PackageInterface;
 use Inpsyde\WpTranslationDownloader\Package\TranslatablePackage;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +17,13 @@ class TranslatablePackageTest extends TestCase
     public function testProjectName(string $input, string $expected): void
     {
         $package = new Package($input, '1.0.0.0', '1.0.0');
-        $translatablePackage = new TranslatablePackage($package, __DIR__, 'https://example.com');
+        $translatablePackage = new TranslatablePackage(
+            $package,
+            __DIR__,
+            'https://example.com',
+            null,
+            []
+        );
 
         static::assertSame($expected, $translatablePackage->projectName());
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Previously the JSON data was downloaded via file_get_contents() which did not allow to make use of the stored credentials in composer config file. This implementation will make use of the Composer HttpDownloader which uses internally the Composer Config and the stored credentials to send alongside with the Request API Tokens or Basic Auth credentials.



**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

**Other information**:

See #35 