### PR TITLE
Fix `wpackagist` vendor names

### DIFF
--- a/tests/Unit/Config/PluginConfigurationTest.php
+++ b/tests/Unit/Config/PluginConfigurationTest.php
@@ -107,11 +107,11 @@ class PluginConfigurationTest extends TestCase
         ];
 
         yield 'Exclude specific and wildcard' => [
-            ['inpsyde/google-tag-manager', 'wpackagist-plugins/*'],
+            ['inpsyde/google-tag-manager', 'wpackagist-plugin/*'],
             [
                 'inpsyde/google-tag-manager' => true,
-                'wpackagist-plugins/wordpress-seo' => true,
-                'wpackagist-themes/twentytwenty' => false,
+                'wpackagist-plugin/wordpress-seo' => true,
+                'wpackagist-theme/twentytwenty' => false,
                 'inpsyde/multilingualpress' => false,
             ],
         ];


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
In the tests, we use Composer vendor names `wpackagist-plugins` and `wpackagist-themes`.


**What is the new behavior (if this is a feature change)?**
Changed the test to use the correct singular vendor names `wpackagist-plugin` and `wpackagist-theme` ([reference](https://wpackagist.org/#:~:text=wpackagist%2Dplugin%20or%20wpackagist%2Dtheme)). 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
