### PR TITLE
Raise version phpunit

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
         composer-version: [ 'v2.1', 'v2.2', 'v2.3', 'v2.4', 'v2.5' ]
         include:
           -   php-version: '8.1'

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -37,7 +37,7 @@ jobs:
   tests-unit-php:
     strategy:
       matrix:
-        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3"]
     uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -24,7 +24,7 @@ jobs:
   lint-php:
     strategy:
       matrix:
-        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3"]
     uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
     with:
       PHP_VERSION: ${{ matrix.php }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,10 @@
 ### Composer template
 composer.phar
 /vendor/
-composer.lock
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+composer.lock
 
 .phpunit.result.cache
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "mikey179/vfsstream": "^v1.6.10",
         "composer/composer": "^2.3.7",
         "inpsyde/php-coding-standards": "^1.0.0",
-        "phpunit/phpunit": "^8.5.26",
+        "phpunit/phpunit": "^9.6.0",
         "vimeo/psalm": "^4.23.0",
         "ondram/ci-detector": "^4.1.0"
     },
@@ -48,7 +48,10 @@
         "behat": "@php ./vendor/bin/behat",
         "cs": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
         "psalm": "@php ./vendor/vimeo/psalm/psalm --no-cache --output-format=compact --find-unused-psalm-suppress",
-        "tests": "@php ./vendor/phpunit/phpunit/phpunit --coverage-text",
+        "tests": [
+            "@putenv XDEBUG_MODE=coverage",
+            "@php ./vendor/phpunit/phpunit/phpunit --coverage-text"
+        ],
         "tests:no-coverage": "@php ./vendor/phpunit/phpunit/phpunit --no-coverage",
         "tests:unit": "@php ./vendor/phpunit/phpunit/phpunit --testsuite Unit",
         "qa": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,16 @@
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="./tests/boot.php"
-         colors="true">
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit/</directory>
-        </testsuite>
-    </testsuites>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./tests/boot.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
**PHPUnit version 9** is the latest compatible with **PHP 8.0** (and _7.3_ + _7.4_). This PR updates the version in composer.json and migrates _phpunit.xml.dist_ to reflect the version change. Additionally, the scripts section has been updated to set the _XDEBUG_MODE_ parameter to _coverage_ when needed.

<img width="576" alt="Bildschirmfoto 2024-10-18 um 16 11 37" src="https://github.com/user-attachments/assets/62984f06-4b2e-44e7-b210-05d8bf7aaf5a">

This change would fully retire support for PHP 7.2 and 7.3. A new version could be tagged as 3.0 to reflect this major update.